### PR TITLE
Remove extra space on some comments

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -22,6 +22,10 @@
   font-size: x-small;
 }
 
+.item--hn-text p:last-of-type {
+  margin-bottom: 0;
+}
+
 .level-border-orange {
   border-left: .16rem solid rgb(252, 183, 127);
 }

--- a/src/Item.tsx
+++ b/src/Item.tsx
@@ -117,7 +117,7 @@ const Item = ({ id, level = 0 }: { id: number, level?: number }) => {
           {data.deleted && '[deleted]'}
           {data.title && <h4>{data.title}</h4>}
           {data.type === 'poll' && <p>Polls are not supported yet!</p>}
-          <div dangerouslySetInnerHTML={{ '__html': DOMPurify.sanitize(data.text || '') }} />
+          <div className="item--hn-text" dangerouslySetInnerHTML={{ '__html': DOMPurify.sanitize(data.text || '') }} />
         </div>
         {topLevel && <div className="p-2 gray-background border-top"><LinkToHN id={id} /></div>}
         {data.kids?.map(itemId => <Item id={itemId} key={itemId} level={level + 1} />)}


### PR DESCRIPTION
Comments that end in `<p>` have extra margin at the bottom. Make uniform across comments.

### Before
![image](https://user-images.githubusercontent.com/2523386/75135692-f9481780-56a7-11ea-8df6-6993315dca6d.png)

### After
![image](https://user-images.githubusercontent.com/2523386/75135709-0d8c1480-56a8-11ea-8984-4d7443e87f0f.png)
