### PR TITLE
Floating button to traverse comments

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -2,6 +2,7 @@
   /* user-select: none; // only for frontpage? */
   color: black;
   max-width: 650px;
+  touch-action: manipulation;
 }
 
 .story--container {

--- a/src/App.css
+++ b/src/App.css
@@ -63,6 +63,13 @@
   text-decoration: none;
 }
 
+.floating-button {
+  position: fixed;
+  bottom: 30px;
+  right: 10px;
+  z-index: 99;
+}
+
 /* utils */
 .clickable {
   cursor: pointer;

--- a/src/App.css
+++ b/src/App.css
@@ -71,7 +71,7 @@
   border-top: 0.01em solid gainsboro;
 }
 
-.border-right {
+.h-border-right {
   border-right: 0.01em solid gainsboro;
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,7 @@ import smoothscroll from 'smoothscroll-polyfill';
 import './App.css';
 import './skeleton.css';
 import FrontPage from './FrontPage';
-import Item from './Item';
+import ItemPage from './Item';
 
 smoothscroll.polyfill();
 
@@ -19,7 +19,7 @@ const App = () => {
           <Route path="/item" render={({ location }) => {
             const searchParams = new URLSearchParams(location.search);
             const id = searchParams.get('id');
-            if (id) return <Item id={parseInt(id, 10)} />;
+            if (id) return <ItemPage id={parseInt(id, 10)} />;
             return <div>No item id specified</div>
           }}>
           </Route>

--- a/src/Item.tsx
+++ b/src/Item.tsx
@@ -25,7 +25,7 @@ interface HNItem {
 
 const hNItemLink = (id: number) => `https://news.ycombinator.com/item?id=${id}`;
 
-const buttonBarClasses = "d-inline-flex align-items-center py-2 px-2";
+const buttonBarClasses = "d-inline-flex align-items-center h-border-right py-2 px-2";
 
 const LinkToHN = ({ id }: { id: number }) => (
   <a className={`${buttonBarClasses}`} role="button" href={hNItemLink(id)}>

--- a/src/Item.tsx
+++ b/src/Item.tsx
@@ -1,7 +1,7 @@
-import React, { useEffect, useState, useRef, RefObject } from 'react';
+import React, { useEffect, useState, useRef, RefObject, Fragment } from 'react';
 import ReactDOM from 'react-dom';
 import DOMPurify from 'dompurify';
-import { Collapse } from 'reactstrap';
+import { Collapse, Button } from 'reactstrap';
 import Icon from './icons/Icon';
 
 // https://github.com/HackerNews/API#items
@@ -26,6 +26,14 @@ interface HNItem {
 const hNItemLink = (id: number) => `https://news.ycombinator.com/item?id=${id}`;
 
 const buttonBarClasses = "d-inline-flex align-items-center h-border-right py-2 px-2";
+
+const topLevelCommentRefs: RefObject<HTMLElement>[] = [];
+
+const topOfElIsVisible = (el: RefObject<HTMLElement>, buffer = 0) => {
+  const top = el.current?.getBoundingClientRect().top;
+  if (top === undefined) return false;
+  return top < buffer;
+}
 
 const LinkToHN = ({ id }: { id: number }) => (
   <a className={`${buttonBarClasses}`} role="button" href={hNItemLink(id)}>
@@ -99,13 +107,9 @@ const Item = ({ id, level = 0 }: { id: number, level?: number }) => {
     getItem();
   }, [id]);
 
-  const topOfElIsVisible = (el: RefObject<HTMLElement>) => {
-    const top = el.current?.getBoundingClientRect().top;
-    if (top === undefined) return false;
-    return top < 0;
-  }
-
   const containerEl = useRef<HTMLDivElement>(null);
+  if (level === 1) topLevelCommentRefs.push(containerEl);
+
   const [isOpen, setIsOpen] = useState(true);
   const toggle = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
     if (level === 0) return;
@@ -167,4 +171,24 @@ const Item = ({ id, level = 0 }: { id: number, level?: number }) => {
   );
 }
 
-export default Item;
+const ItemPage = ({ id }: { id: number }) => {
+  const goToNextComment = () => {
+    const firstCommentWithTopVisible = topLevelCommentRefs.filter(e => !topOfElIsVisible(e, 5))[0];
+
+    if (firstCommentWithTopVisible && firstCommentWithTopVisible?.current) {
+      window.scrollTo({ top: firstCommentWithTopVisible.current.offsetTop, behavior: 'smooth' });
+    }
+  }
+
+  return (
+    <>
+      <Item id={id} />
+      <Button size="lg" color="dark" className="rounded-circle floating-button d-md-none" onClick={goToNextComment}>
+        &darr;
+      </Button>
+      <div className="d-md-none" style={{ paddingBottom: '80px' }}></div>
+    </>
+  );
+};
+
+export default ItemPage;

--- a/src/Story.tsx
+++ b/src/Story.tsx
@@ -43,6 +43,7 @@ const Story = ({ id, rank }: { id: number, rank: number }) => {
         <a
           className="px-2 pt-2 col-sm-11 col-10"
           href={storyData.url || `https://news.ycombinator.com/item?id=${id}`}
+          rel="noopener noreferrer" target="_blank"
         >
           <div className={loadingClassName}>{storyData.title}</div>
           <span className={`${loadingClassName} text-muted story--info pt-1`}>
@@ -52,6 +53,7 @@ const Story = ({ id, rank }: { id: number, rank: number }) => {
         <Link
           className="col-sm-1 col-2 pl-1 pr-1 pt-2 story--comments"
           to={`/item?id=${id}`}
+          rel="noopener noreferrer" target="_blank"
         >
           <span className={`${loadingClassName} float-right small`} style={{ display:'flex', alignItems: 'center' }}>
             {storyData.descendants}&nbsp;<Icon name="chat-bubbles" />

--- a/src/Story.tsx
+++ b/src/Story.tsx
@@ -53,7 +53,7 @@ const Story = ({ id, rank }: { id: number, rank: number }) => {
           className="col-sm-1 col-2 pl-1 pr-1 pt-2 story--comments"
           to={`/item?id=${id}`}
         >
-          <span className="float-right small" style={{ display:'flex', alignItems: 'center' }}>
+          <span className={`${loadingClassName} float-right small`} style={{ display:'flex', alignItems: 'center' }}>
             {storyData.descendants}&nbsp;<Icon name="chat-bubbles" />
           </span>
         </Link>


### PR DESCRIPTION
Adds ItemPage component and button that will go to next (top level) comment (only shows on small screens). Disable double tap (touch) to zoom. +some fixes

# screenshot (Chrome, so doesn't show share button)

![localhost_3000_(iPhone X)](https://user-images.githubusercontent.com/2523386/75321899-5f16d980-5837-11ea-9c82-a9d0456acdae.png)
