### PR TITLE
Add dapper link cards for hacker news item links

### DIFF
--- a/src/item/Item.tsx
+++ b/src/item/Item.tsx
@@ -88,9 +88,10 @@ export const Item = ({ id, level = 0, addTopLevelCommentRef }: { id: number, lev
     const selection = window.getSelection();
     if (selection?.type === 'Range') return;
 
-    // do not collapse comment if clicking on link inside div (HTML from api)
+    // do not collapse comment if clicking on link inside div (HTML from api), or link icon, or dapper link at bottom
     const target = e.target as HTMLElement;
     if (target.nodeName === 'A' || target.nodeName === 'svg') return;
+    if (target.parentNode?.nodeName === 'A' || target.parentNode?.nodeName === 'svg') return;
 
     e.stopPropagation();
     setIsOpen(!isOpen);

--- a/src/item/Item.tsx
+++ b/src/item/Item.tsx
@@ -115,6 +115,15 @@ export const Item = ({ id, level = 0, addTopLevelCommentRef }: { id: number, lev
   const commentCss = level > 1 ? `${levelBorderColor()} ml-3` : '';
   const topLevel = level === 0;
 
+  let linksToHn: string[] = [];
+  if (data.text) {
+    let regexp = /news\.ycombinator\.com\S+item\?id=\d*/g;
+    let matches = [...data.text.matchAll(regexp)]
+
+    const ids = matches.map(a => a[0]).map(a => a.split('=')[1]);
+    linksToHn = [...new Set(ids)];
+  }
+
   return (
     <div ref={containerEl} className={`${commentCss} ${level > 0 ? 'h-border-top' : ''} px-0 `} onClick={toggle}>
       <div className={`${isLoadingClassName} text-muted small pt-1 px-2`} style={{ display: 'flex', alignItems: 'center' }}>
@@ -141,6 +150,12 @@ export const Item = ({ id, level = 0, addTopLevelCommentRef }: { id: number, lev
           {data.type === 'poll' && <p>Polls are not supported yet!</p>}
           <div className="item--hn-text" dangerouslySetInnerHTML={{ '__html': DOMPurify.sanitize(data.text || '') }} />
         </div>
+
+        {/* If item contains link to hacker news item, add link cards to dapper version of item */}
+        {linksToHn.map(id => <div className="mt-2 mx-2">
+          <LinkUrlCard url={`https://dapper.dilraj.dev/item?id=${id}`} />
+        </div>)}
+
         {
           topLevel &&
           <div className="h-border-top d-flex align-items-center">

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react"
+    "jsx": "react",
+    "downlevelIteration": true
   },
   "include": [
     "src"


### PR DESCRIPTION
Sometimes comments will reference other hacker news threads. Want to be able to see these inside dapper and not on news.ycombinator.com. 

This PR adds link cards to the bottom of an item that links to hacker news items so they can be viewed in dapper.

![image](https://user-images.githubusercontent.com/2523386/82722728-d6b9a080-9c8e-11ea-93f6-51c99bfc3cf1.png)

