### PR TITLE
Improve API null and error cases

### DIFF
--- a/src/api/HNApiTypes.ts
+++ b/src/api/HNApiTypes.ts
@@ -16,4 +16,9 @@ export interface HNItem {
   title?: string; // The title of the story, poll or job. HTML.
   parts?: number[]; // the pollopts of a poll
   descendants?: number;
+
+  /**
+   * ADDED BY ME
+   */
+  error?: boolean;
 }

--- a/src/api/getItemFromApi.ts
+++ b/src/api/getItemFromApi.ts
@@ -22,6 +22,23 @@ const getItemFromApi: IGetItemFromApi = async (id: number) => {
   );
 
   const data: HNItem | null = await response.json();
+
+  if (!data) return null;
+
+  if (data.deleted) {
+    return {
+      id: id,
+      by: '[deleted]',
+      text: '[deleted]',
+      deleted: true
+    };
+  }
+
+  // TODO: Verify what it means if this is empty
+  // if (!data.by) {
+  //   data.by = '[deleted]';
+  // }
+
   return data;
 };
 

--- a/src/components/item/Item.tsx
+++ b/src/components/item/Item.tsx
@@ -59,7 +59,7 @@ export const Item = ({
           data || {
             id,
             text: `API error :( <a href="${hNItemLink(id)}">view on hn</a>`,
-            type: 'comment'
+            error: true
           }
         );
       });

--- a/src/components/item/ItemCard.tsx
+++ b/src/components/item/ItemCard.tsx
@@ -149,7 +149,7 @@ export function ItemCard({
           />
         </div>
 
-        {data.text && <LinksToHn text={data.text} />}
+        {data.text && !data.error && <LinksToHn text={data.text} />}
 
         {topLevel && <ShareBar id={id} title={data.title} />}
 

--- a/src/components/item/ItemCard.tsx
+++ b/src/components/item/ItemCard.tsx
@@ -28,7 +28,7 @@ export const TitleBar = ({
     className={`${isLoadingClassName} text-muted small pt-1 px-2`}
     style={{ display: 'flex', alignItems: 'center' }}
   >
-    {data.by || '[deleted]'} {/* TODO: Verify what it means if this is empty */}
+    {data.by} {/*TOOD remove this breaks snapshot test*/}
     {topLevel && (
       <>
         &emsp;{data.score && `↑${data.score}`}&emsp;
@@ -132,7 +132,6 @@ export function ItemCard({
           className={`${isLoadingClassName} py-1 px-2`}
           style={{ wordBreak: 'break-word' }}
         >
-          {data.deleted && '[deleted]'}
           {data.title && (
             <h4
               dangerouslySetInnerHTML={{


### PR DESCRIPTION
Handle error cases better

1. Deleted comments have `id`s now, so if you click on the perma link icon, you will go to the id instead of `item?id=undefined`

2. Comments that have an api error will no longer show dapper mirror links to hn