### PR TITLE
A "smart" spinner hook with delay and min time to show spinner

### DIFF
--- a/src/api/getItemsFromApi.ts
+++ b/src/api/getItemsFromApi.ts
@@ -1,3 +1,5 @@
+// import { sleep } from '../components/item/helpers';
+
 export type StoryTypes = 'top'; //'top' | 'best' | 'new'...
 
 const typeToUrl = {
@@ -5,9 +7,14 @@ const typeToUrl = {
 };
 
 const getItemsFromApi = async (type: StoryTypes = 'top') => {
+  console.log('GET>>');
+
   const response = await fetch(typeToUrl[type]);
   const data: number[] = await response.json();
 
+  // await sleep(2000);
+
+  console.log('GET DONE____');
   return data;
 };
 

--- a/src/components/FrontPage.tsx
+++ b/src/components/FrontPage.tsx
@@ -3,6 +3,8 @@ import { TransitionGroup, CSSTransition } from 'react-transition-group';
 import Story from './Story';
 import Icon from './Icon';
 import { FloatingButton } from './FloatingButton';
+import useDelayedLoading from './useDelayedLoading';
+import { Spinner } from 'reactstrap';
 import getItemsFromApi, { StoryTypes } from '../api/getItemsFromApi';
 
 const LOAD_INCREMENT = 30;
@@ -22,15 +24,25 @@ const FrontPage = ({ storyType = 'top' }: { storyType?: StoryTypes }) => {
   const [storiesToHide, setStoriesToHide] = useState<number[]>([]);
   const hideViewedStories = () => setStoriesToHide(viewedStories);
 
+  const [setIsLoading, showSpinner, isLoading] = useDelayedLoading();
+
   useEffect(() => {
     async function getStories() {
+      console.log('>>');
+      setIsLoading(true);
+
       const data = await getItemsFromApi(storyType);
 
+      setIsLoading(false);
       setStories(data);
     }
 
     getStories();
-  }, [storyType]);
+  }, [
+    storyType,
+    //
+    setIsLoading
+  ]);
 
   useEffect(() => {
     // TODO change to calculating on this document vs. App div
@@ -83,6 +95,16 @@ const FrontPage = ({ storyType = 'top' }: { storyType?: StoryTypes }) => {
   );
 
   const viewedStory = (id: number) => viewedStories.indexOf(id) > -1;
+
+  console.log('__rendering__');
+
+  if (isLoading && !showSpinner) return <></>; // no need for this
+  if (showSpinner)
+    return (
+      <div className="d-flex justify-content-center">
+        <Spinner />
+      </div>
+    );
 
   return (
     <>

--- a/src/components/useDelayedLoading.tsx
+++ b/src/components/useDelayedLoading.tsx
@@ -1,0 +1,134 @@
+import { useState, useCallback } from 'react';
+
+// window.setTimeout(ticker, MIN_SPINNER_SHOW_TIME - elapsed);
+
+/**
+ *
+ * @param delaySpinnerMs milliseconds to wait before showing spinner
+ * @param minSpinnerMs minimum milliseconds to show spinner
+ * @returns [setLoading, showSpinner, isLoading]
+ */
+export default function useDelayedLoading(
+  delaySpinnerMs: number = 500,
+  minSpinnerMs: number = 500
+) {
+  const [loadingState, setLoadingState] = useState<{
+    startedLoading?: number;
+    startedSpinner?: number;
+    showSpinnerTimeoutId?: number;
+    hideSpinnerTimeoutId?: number;
+  }>({});
+
+  const setLoading = useCallback(
+    (isLoading: boolean) => {
+      /**
+       * Started loading
+       */
+      if (isLoading) {
+        setLoadingState(loadingState => {
+          /**
+           * Clear all existing timeouts
+           * Edge case: calling setLoading(true) when already loading
+           */
+          window.clearTimeout(loadingState.showSpinnerTimeoutId);
+          window.clearTimeout(loadingState.hideSpinnerTimeoutId);
+
+          return {
+            startedLoading: Date.now(),
+            showSpinnerTimeoutId: window.setTimeout(() => {
+              setLoadingState(newLoadingState => {
+                // Is this check needed if this gets cleared on setLoading(false)
+                if (
+                  newLoadingState.startedLoading &&
+                  Date.now() - newLoadingState.startedLoading > delaySpinnerMs
+                ) {
+                  return { ...newLoadingState, startedSpinner: Date.now() };
+                }
+                return newLoadingState;
+              });
+            }, delaySpinnerMs)
+            // startedSpinner: loadingState.startedSpinner // if already showing spinner, reset
+          };
+        });
+      }
+
+      //
+      /**
+       * Stopped loading
+       */
+      else {
+        setLoadingState(loadingState => {
+          /**
+           * Clear loadingTimer
+           *
+           * Edge case: setLoading(false) when already false
+           * Do not clear the hide spinner timer, want to keep orginal timeout function
+           *
+           * If there is already a function to clear the spinner, clear loading state and return
+           */
+          window.clearTimeout(loadingState.showSpinnerTimeoutId);
+          // if (loadingState.hideSpinnerTimeoutId) {
+          //   return {
+          //     ...loadingState,
+          //     startedLoading: undefined,
+          //     showSpinnerTimeoutId: undefined
+          //   };
+          // }
+
+          /**
+           * Currently showing spinner
+           */
+          if (loadingState.startedSpinner) {
+            const elapsedSpinnerTime = Date.now() - loadingState.startedSpinner;
+
+            /**
+             * Have shown spinner for required time, hide and set all to false
+             */
+            if (elapsedSpinnerTime > minSpinnerMs) {
+              window.clearTimeout(loadingState.hideSpinnerTimeoutId);
+              return {};
+            }
+
+            /**
+             * Have not shown spinner for required time, hide spinner in the future
+             */
+            return {
+              ...loadingState,
+              hideSpinnerTimeoutId: window.setTimeout(() => {
+                setLoadingState(newLoadingState => {
+                  window.clearTimeout(newLoadingState.showSpinnerTimeoutId);
+                  window.clearTimeout(newLoadingState.hideSpinnerTimeoutId);
+                  return {};
+                });
+              }, minSpinnerMs - elapsedSpinnerTime)
+            };
+          }
+
+          /**
+           * Currently not showing spinner,
+           * - clear all values
+           * - clear any old hide spinner timeouts -- no spinner to hide
+           */
+          window.clearTimeout(loadingState.hideSpinnerTimeoutId);
+          return {};
+        });
+      }
+    },
+
+    // only change if the config is changed
+    [delaySpinnerMs, minSpinnerMs]
+  );
+
+  // is there a way to guarantee all timer's are cleared?
+  // useEffect(() => {
+  //   return () => window.clearTimeout(loadingState.timerId);
+  // }, []);
+
+  console.log('useDelayedLoading recomputed');
+
+  return [
+    setLoading,
+    !!loadingState.startedSpinner,
+    !!loadingState.startedLoading
+  ] as const;
+}


### PR DESCRIPTION
A spinner that flashes in to be instantly replaced is an annoying user experience.

So, this hook offers a way to set a delay before you show the spinner (e.g. 500ms).

However, a spinner that shows up after a delay, but is instantly replaced, is also an annoying user experience (e.g. if the API took 550ms, you would only see the spinner for 50ms).

So, this hook also offers a way to set a minimum amount of time that you will keep showing the spinner, (even if the data fetching is done).
