### PR TITLE
Max depth of comments to show

### DIFF
--- a/src/components/item/ItemCard.tsx
+++ b/src/components/item/ItemCard.tsx
@@ -168,7 +168,21 @@ export function ItemCard({
 
         {topLevel && <ShareBar id={data.id} title={data.title} />}
 
-        {kids}
+        {kids && level > 5 ? (
+          <div className={`pl-2 pt-2`}>
+            ---
+            <br />
+            <Link
+              rel="noopener noreferrer"
+              target="_blank"
+              to={`/item?id=${data.id}`}
+            >
+              Load more replies {'>>'}
+            </Link>
+          </div>
+        ) : (
+          kids
+        )}
       </Collapse>
     </div>
   );


### PR DESCRIPTION
Do not show children for comments 6 levels deep. instead, show a link to load that item (in a new tab) and view replies.
Does not show link if comment at that level has no children.

![image](https://user-images.githubusercontent.com/2523386/105571325-fb758480-5d03-11eb-8362-1ddc017b18cf.png)
